### PR TITLE
Added copying of nodemanager files into target

### DIFF
--- a/scripts/config_build.txt
+++ b/scripts/config_build.txt
@@ -3,6 +3,7 @@ DEPENDENCIES/seattlelib_v2/*
 DEPENDENCIES/repy_v2/*
 DEPENDENCIES/portability/*
 DEPENDENCIES/common/*
+DEPENDENCIES/nodemanager/*
 
 # Tests
 test DEPENDENCIES/common/utf/*


### PR DESCRIPTION
softwareupdater.py imports daemon module. And this requires the files of nodemanager to be copied over to the TARGET dir. Otherwise it throws import error!
