### PR TITLE
Import a required module.  Address Issue #49

### DIFF
--- a/softwareupdater.py
+++ b/softwareupdater.py
@@ -62,11 +62,6 @@ signeddata = dy_import_module('signeddata.r2py')
 sha = dy_import_module('sha.r2py')
 time = dy_import_module('time.r2py')
 
-
-dy_import_module_symbols("signeddata.r2py")
-dy_import_module_symbols("sha.r2py")
-dy_import_module_symbols("time.r2py")
-
 # Armon: The port that should be used to update our time using NTP
 TIME_PORT = 51234
 TIME_PORT_2 = 42345


### PR DESCRIPTION
Address Isssue #49.

`softwareupdater.py` raises an exception when it tries to update its local time via NTP during an update.  The message logged is `[do_rsync] Unable to update ntp time. Not updating`, however, updating the time via NTP was found to be functioning correctly.  After some tracing and troubleshooting, the root cause of the NTP exception was found to be an import issue: `global name 'time_updatetime' is not defined`.  It appears `softwareupdater.py` has not been importing a required `time.r2py` module.  It is unclear how this module has been working correctly until now. (perhaps repy2 changed the way imports are handled?)  In addition to issues with exception handling, the `softwareupdater.py` unit tests produce different results after every invocation (temp files are not properly removed, processes killed, etc?)
